### PR TITLE
Remove the need to call buildGpuBuffer() on scene objects.

### DIFF
--- a/demos/demo-01/src/model-builder.ts
+++ b/demos/demo-01/src/model-builder.ts
@@ -1,16 +1,20 @@
 import { Transform } from '@shaders-mono/geopro';
-import { Gpu, createTexture, TriangleData, Scene, MouseLocation, getOrbitHandlers } from '@shaders-mono/webgpu';
+import { Gpu, createTexture, Scene, MouseLocation, getOrbitHandlers } from '@shaders-mono/webgpu';
 import * as WebGPU from '@shaders-mono/webgpu';
 
-export const buildScene = async (gpu: Gpu, trimesh: TriangleData, imageId: string): Promise<Scene> => {
+export const buildScene = async (gpu: Gpu, trimesh: WebGPU.GeoRenderable, imageId: string): Promise<Scene> => {
   const textureEl = document.getElementById(imageId) as HTMLImageElement;
   const image = await createImageBitmap(textureEl);
 
   const material = createTexture(gpu, image);
-  trimesh.buildGpuBuffer(gpu);
   return [[trimesh, material]];
 };
 
+/**
+ *
+ * @param canvasEl
+ * @param supportEl
+ */
 export async function init(canvasEl: HTMLCanvasElement, supportEl: HTMLParagraphElement) {
   const gpu = await WebGPU.initialize(canvasEl);
 

--- a/demos/demo-02/src/gpu/init.ts
+++ b/demos/demo-02/src/gpu/init.ts
@@ -1,8 +1,8 @@
 import { Transform } from '@shaders-mono/geopro';
 import * as WebGPU from '@shaders-mono/webgpu';
-import type { Gpu, Scene } from '@shaders-mono/webgpu';
+import type { Scene } from '@shaders-mono/webgpu';
 
-const buildScene = async (gpu: Gpu): Promise<Scene> => {
+const buildScene = async (): Promise<Scene> => {
   const color2: WebGPU.RGBAColor = [0.5, 0.5, 1.0, 1.0];
   const color3: WebGPU.RGBAColor = [0.8, 0.3, 1.0, 1.0];
 
@@ -41,15 +41,6 @@ const buildScene = async (gpu: Gpu): Promise<Scene> => {
     Transform.scale(1.5, 1.5, 1.5).translation(-15, 15, 0.0), // , // Keep the sphere in the center
     { steps: 3, color: [1, 1, 0, 1] }
   );
-  plane.buildGpuBuffer(gpu);
-  sphere0.buildGpuBuffer(gpu);
-  sphere1.buildGpuBuffer(gpu);
-  sphere2.buildGpuBuffer(gpu);
-  sphere3.buildGpuBuffer(gpu);
-  sphere4.buildGpuBuffer(gpu);
-  cylinder.buildGpuBuffer(gpu);
-  cube.buildGpuBuffer(gpu);
-  grid.buildGpuBuffer(gpu);
 
   return [[cube], [sphere0], [sphere1], [sphere2], [sphere3], [sphere4], [cylinder], [plane], [grid]];
 };
@@ -58,7 +49,7 @@ export const init = async (canvas: HTMLCanvasElement) => {
   const gpu = await WebGPU.initialize(canvas);
   await gpu.setupShaders('standard-3d');
 
-  const scene = await buildScene(gpu);
+  const scene = await buildScene();
   await gpu.setupGeoBuilder(scene);
 
   const [mouseHandlers, viewHandlers] = WebGPU.getOrbitHandlers(gpu);

--- a/shared/webgpu/src/gpu-connection.ts
+++ b/shared/webgpu/src/gpu-connection.ts
@@ -116,9 +116,15 @@ export class Gpu implements GPUConnection {
     if (!this._shaderModule) {
       throw new Error('WebGPU:shader module is NOT available!');
     }
-    // Setup the GPU pipeline with the compiled shaders
+    // 1 - Setup the GPU buffers for the scene
+    scene.forEach(([geo, _]) => {
+      geo.buildGpuBuffer(this);
+    });
+
+    // 2 - Setup the GPU pipeline with the compiled shaders
     this._pipelines = createPipelines(this, this._shaderModule, scene);
 
+    // 3 - Setup the render pass descriptor
     this._renderPassDescription = buildRenderPassDescriptor(this);
   }
 


### PR DESCRIPTION
Remove the need to explicitly call `buildGpuBuffer()` This is now done when calling `setupGeoBuilder()` on the GpuConnection.